### PR TITLE
Add InputStream read access to the ArchiveService.

### DIFF
--- a/archive/src/main/java/org/opentestsystem/rdw/archive/ArchiveService.java
+++ b/archive/src/main/java/org/opentestsystem/rdw/archive/ArchiveService.java
@@ -37,6 +37,14 @@ public interface ArchiveService {
     byte[] readResource(String location);
 
     /**
+     * Read a resource identified by the unique id.
+     *
+     * @param location unique (relative) location for content, e.g. "EXAM/4F/0A/4F0A1245"
+     * @return a content stream, null if not found
+     */
+    InputStream readResourceAsStream(String location);
+
+    /**
      * Read the properties for the given resource location.
      *
      * @param location unique (relative) location for content

--- a/archive/src/main/java/org/opentestsystem/rdw/archive/LocalArchiveService.java
+++ b/archive/src/main/java/org/opentestsystem/rdw/archive/LocalArchiveService.java
@@ -83,15 +83,27 @@ public class LocalArchiveService implements ArchiveService {
 
     @Override
     public byte[] readResource(final String location) {
+        try (final InputStream is = readResourceAsStream(location)) {
+            if (is == null) return null;
+
+            return StreamUtils.copyToByteArray(new BufferedInputStream(is));
+        } catch (final IOException e) {
+            final String msg = "Error reading content from " + realResourceFile(location).getPath();
+            logger.warn(msg, e);
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    @Override
+    public InputStream readResourceAsStream(final String location) {
         final File file = realResourceFile(location);
         if (!file.exists()) {
             return null;
         }
-
-        try (final InputStream is = new BufferedInputStream(new FileInputStream(file))) {
-            return StreamUtils.copyToByteArray(is);
+        try {
+            return new FileInputStream(file);
         } catch (final IOException e) {
-            final String msg = "Error reading content from " + file.getPath();
+            final String msg = "Error opening content from " + file.getPath();
             logger.warn(msg, e);
             throw new RuntimeException(msg, e);
         }

--- a/archive/src/main/java/org/opentestsystem/rdw/archive/S3ArchiveService.java
+++ b/archive/src/main/java/org/opentestsystem/rdw/archive/S3ArchiveService.java
@@ -87,8 +87,21 @@ public class S3ArchiveService implements ArchiveService, InitializingBean {
 
     @Override
     public byte[] readResource(final String location) {
-        try (final InputStream is = new BufferedInputStream(amazonS3.getObject(bucket, location).getObjectContent())) {
-            return StreamUtils.copyToByteArray(is);
+        try (final InputStream is = readResourceAsStream(location)) {
+            if (is == null) return null;
+
+            return StreamUtils.copyToByteArray(new BufferedInputStream(is));
+        } catch (final IOException e) {
+            final String msg = "Error reading content from " + bucket + location;
+            logger.warn(msg, e);
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    @Override
+    public InputStream readResourceAsStream(final String location) {
+        try {
+            return amazonS3.getObject(bucket, location).getObjectContent();
         } catch (final AmazonServiceException e) {
             if (e.getStatusCode() == 404 || e.getStatusCode() == 301) {
                 return null;
@@ -96,10 +109,6 @@ public class S3ArchiveService implements ArchiveService, InitializingBean {
             final String msg = "Amazon error reading content from " + bucket + location;
             logger.warn(msg, e);
             throw e;
-        } catch (final IOException e) {
-            final String msg = "Error reading content from " + bucket + location;
-            logger.warn(msg, e);
-            throw new RuntimeException(msg, e);
         }
     }
 

--- a/archive/src/test/java/org/opentestsystem/rdw/archive/LocalArchiveServiceTest.java
+++ b/archive/src/test/java/org/opentestsystem/rdw/archive/LocalArchiveServiceTest.java
@@ -5,9 +5,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
+import static com.amazonaws.util.IOUtils.toByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalArchiveServiceTest {
@@ -43,6 +46,29 @@ public class LocalArchiveServiceTest {
         final byte[] content = "TestyMcTestFace".getBytes("UTF-8");
         service.writeResource("f1/f2/test", content, properties);
         assertThat(service.readResource("f1/f2/test")).isEqualTo(content);
+
+        final Properties readProperties = service.readProperties("f1/f2/test");
+        assertThat(readProperties).hasSize(2);
+        assertThat(readProperties.getProperty("content-type")).isEqualTo("text/plain");
+        assertThat(readProperties.getProperty("message")).isEqualTo("hi");
+    }
+
+    @Test
+    public void itShouldWriteAndReadContentInLocationUsingStreams() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty("content-type", "text/plain");
+        properties.setProperty("message", "hi");
+
+        final byte[] srcContent = "TestyMcTestFace".getBytes("UTF-8");
+
+        try (final InputStream writeStream = new ByteArrayInputStream(srcContent)) {
+            service.writeResource("f1/f2/test", writeStream, properties);
+
+            try (final InputStream readStream =  service.readResourceAsStream("f1/f2/test")) {
+                final byte[] readContent = toByteArray(readStream);
+                assertThat(readContent).isEqualTo(srcContent);
+            }
+        }
 
         final Properties readProperties = service.readProperties("f1/f2/test");
         assertThat(readProperties).hasSize(2);

--- a/archive/src/test/java/org/opentestsystem/rdw/archive/S3ArchiveServiceIT.java
+++ b/archive/src/test/java/org/opentestsystem/rdw/archive/S3ArchiveServiceIT.java
@@ -10,10 +10,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.util.StreamUtils.copyToByteArray;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
@@ -62,5 +65,20 @@ public class S3ArchiveServiceIT {
         assertThat(readProperties).hasSize(2);
         assertThat(readProperties.getProperty("content-type")).isEqualTo("text/plain");
         assertThat(readProperties.getProperty("message")).isEqualTo("hi");
+    }
+
+    @Ignore("need credentials")
+    @Test
+    public void itShouldWriteAndReadContentUsingStreams() throws Exception {
+        final byte[] srcContent = "TestyMcTestFace".getBytes("UTF-8");
+
+        try (final InputStream writeStream = new ByteArrayInputStream(srcContent)) {
+            service.writeResource("EXAM/f1/f2/test", writeStream, null);
+
+            try (final InputStream readStream =  service.readResourceAsStream("EXAM/f1/f2/test")) {
+                final byte[] readContent = copyToByteArray(readStream);
+                assertThat(readContent).isEqualTo(srcContent);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR just adds the ability to read an unbuffered InputStream from the ArchiveService.  The goal is to be able to stream a multi-hundred-megabyte report PDF from S3 to the user without copying the whole file to memory.