### PR TITLE
Add codes to assessment type and subject enums.

### DIFF
--- a/model/src/main/java/org/opentestsystem/rdw/common/model/AssessmentType.java
+++ b/model/src/main/java/org/opentestsystem/rdw/common/model/AssessmentType.java
@@ -9,15 +9,17 @@ package org.opentestsystem.rdw.common.model;
  * </p>
  */
 public enum AssessmentType {
-    ICA(1, true),
-    IAB(2, false),
-    SUMMATIVE(3, true);
+    ICA(1, "ica", true),
+    IAB(2, "iab", false),
+    SUMMATIVE(3, "sum", true);
 
     private final int id;
+    private final String code;
     private final boolean hasClaims;
 
-    AssessmentType(final int id, final boolean hasClaims) {
+    AssessmentType(final int id, final String code, final boolean hasClaims) {
         this.id = id;
+        this.code = code;
         this.hasClaims = hasClaims;
     }
 
@@ -45,6 +47,16 @@ public enum AssessmentType {
      */
     public int id() {
         return id;
+    }
+
+    /**
+     * This is the assessment type code.
+     * This value corresponds to the assessment type code in the database
+     *
+     * @return the assessment type code
+     */
+    public String code() {
+        return code;
     }
 
     /**

--- a/model/src/main/java/org/opentestsystem/rdw/common/model/Subject.java
+++ b/model/src/main/java/org/opentestsystem/rdw/common/model/Subject.java
@@ -8,13 +8,15 @@ package org.opentestsystem.rdw.common.model;
  * </p>
  */
 public enum Subject {
-    MATH(1),
-    ELA(2);
+    MATH(1, "Math"),
+    ELA(2, "ELA");
 
     private final int id;
+    private final String code;
 
-    Subject(final int id) {
+    Subject(final int id, final String code) {
         this.id = id;
+        this.code = code;
     }
 
     /**
@@ -41,5 +43,15 @@ public enum Subject {
      */
     public long id() {
         return id;
+    }
+
+    /**
+     * This is the subject code.
+     * This value corresponds to the subject entity code in the database
+     *
+     * @return the subject code
+     */
+    public String code() {
+        return code;
     }
 }


### PR DESCRIPTION
While converting ReportQuery properties from DB ids to codes I find a few places in the code and many in the tests where we are using the AssessmentType and Subject enums to test/populate values.  I'd like to be able to test/populate codes rather than use static strings like "sum."