### PR TITLE
Add AssessmentType.fromCode to lookup an enum by the code

### DIFF
--- a/model/src/main/java/org/opentestsystem/rdw/common/model/AssessmentType.java
+++ b/model/src/main/java/org/opentestsystem/rdw/common/model/AssessmentType.java
@@ -40,6 +40,22 @@ public enum AssessmentType {
     }
 
     /**
+     * Returns the enum constant of this type with the specified code.
+     *
+     * @param code code to look up
+     * @return enum constant with the specified id
+     * @throws IllegalArgumentException if id doesn't match any enum constant
+     */
+    public static AssessmentType fromCode(final String code) {
+        for (final AssessmentType type : values()) {
+            if (type.code().equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown AssessmentType code: " + code);
+    }
+
+    /**
      * This is the assessment type id.
      * This value corresponds to the assessment type entity ID in the database
      *

--- a/model/src/test/java/org/opentestsystem/rdw/common/model/AssessmentTypeTest.java
+++ b/model/src/test/java/org/opentestsystem/rdw/common/model/AssessmentTypeTest.java
@@ -48,4 +48,21 @@ public class AssessmentTypeTest {
     public void itShouldNotConvertFromUnknownStringValue() {
         AssessmentType.valueOf("fubar");
     }
+
+    @Test
+    public void itShouldConvertFromCode() {
+        assertThat(AssessmentType.fromCode("ica")).isEqualTo(AssessmentType.ICA);
+        assertThat(AssessmentType.fromCode("iab")).isEqualTo(AssessmentType.IAB);
+        assertThat(AssessmentType.fromCode("sum")).isEqualTo(AssessmentType.SUMMATIVE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldNotConvertFromUnknownCode() {
+        AssessmentType.fromCode("notvalid");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromCodeIsCaseSensitive() {
+        AssessmentType.fromCode("ICA");
+    }
 }


### PR DESCRIPTION
For the student report processor to handle ICA and Summative we have the code from the request and i'd like to use this to get the AssessmentType enum and therefore the ID for the assessment type to use in the SQL.