### PR TITLE
Add helper to apply an XSL transformation when reading a TDSReport.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 build/
+out/
 
 *.iml
 .idea/

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'io.spring.dependency-management'
 
 allprojects {
     group = 'org.opentestsystem.rdw.common'
-    version = '1.2.0-SNAPSHOT'
+    version = '1.2.2-SNAPSHOT'
 
     apply plugin: 'idea'
     apply plugin: 'propdeps'

--- a/model/src/main/java/org/opentestsystem/rdw/common/model/trt/XmlUtils.java
+++ b/model/src/main/java/org/opentestsystem/rdw/common/model/trt/XmlUtils.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.common.model.trt;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
@@ -7,13 +9,16 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.util.JAXBResult;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import java.io.InputStream;
 import java.io.StringWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class XmlUtils {
@@ -21,9 +26,26 @@ public class XmlUtils {
 
     public static TDSReport tdsReportFromXml(final InputStream is) {
         try {
-            // TODO - ?add fields for xml source schema version, and whether it validated?
             return (TDSReport) createUnmarshaller().unmarshal(is);
         } catch (final JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Unmarshal a TDSReport from an XML stream while applying an XSLT.
+     *
+     * @param is XML stream
+     * @param xsl XSLT stream
+     * @return TDSReport
+     */
+    public static TDSReport tdsReportFromXml(final InputStream is, final InputStream xsl) {
+        try {
+            final JAXBResult result = new JAXBResult(createUnmarshaller());
+            final Transformer transformer = getTransformer(xsl);
+            transformer.transform(new StreamSource(is), result);
+            return (TDSReport) result.getResult();
+        } catch (final JAXBException | TransformerException e) {
             throw new RuntimeException(e);
         }
     }
@@ -64,6 +86,10 @@ public class XmlUtils {
             }
         }
         return schema;
+    }
+
+    private static Transformer getTransformer(final InputStream xsl) throws TransformerConfigurationException {
+        return TransformerFactory.newInstance().newTransformer(new StreamSource(xsl));
     }
 
     private static Marshaller createMarshaller() throws JAXBException {

--- a/model/src/test/java/org/opentestsystem/rdw/common/model/trt/XmlUtilsTest.java
+++ b/model/src/test/java/org/opentestsystem/rdw/common/model/trt/XmlUtilsTest.java
@@ -86,6 +86,16 @@ public class XmlUtilsTest {
         assertThat(tdsReport.getOpportunity().getValidity()).isEqualTo("valid");
     }
 
+    @Test
+    public void itShouldUnmarshalAndTransform() {
+        final TDSReport tdsReport = XmlUtils.tdsReportFromXml(
+                this.getClass().getResourceAsStream("/TDSReport.minimal.xml"),
+                this.getClass().getResourceAsStream("/example.xsl"));
+        assertThat(tdsReport.getTest().getGrade()).isEqualTo("07");
+        assertThat(tdsReport.getTest().getSubject()).isEqualTo("Math");
+        assertThat(tdsReport.getExaminee().getBestRelationship("SchoolID").getValue()).isEqualTo("9999827_9999928");
+    }
+
 
     private void assertSampleTDSReport(final TDSReport tdsReport) {
         assertThat(tdsReport).isNotNull();

--- a/model/src/test/resources/example.xsl
+++ b/model/src/test/resources/example.xsl
@@ -1,0 +1,34 @@
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" omit-xml-declaration="yes" indent="yes"/>
+
+  <!-- identity rule copies everything by default -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- this rule changes subject="MA" to subject="Math" -->
+  <xsl:template match="Test[@subject='MA']/@subject">
+    <xsl:attribute name="subject">
+      <xsl:value-of select="'Math'"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- this rule adds a leading zero to single digit grade -->
+  <xsl:template match="Test/@grade[string-length()=1]">
+    <xsl:attribute name="grade">
+      <xsl:value-of select="'0'"/>
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- this rule removes the leading CA_ from school ids -->
+  <xsl:template match="ExamineeRelationship[@name='SchoolID' and starts-with(@value, 'CA_')]/@value">
+    <xsl:attribute name="value">
+      <xsl:value-of select="substring(., 4)"/>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>
+


### PR DESCRIPTION
This is a supporting change for an enhancement that allows a transformation to be applied to TRT files as they are processed. Please see https://github.com/SmarterApp/RDW_Ingest/pull/546 for more details.

I did a little informal benchmarking. With small transformations (like the example), reading and converting a TRT to the TDSReport data model goes from about 950ms to 1200ms. So it isn't something we want to do if we don't need to (you'll see how that is handled in the RDW_Ingest changes).

Sorry to drag you into these reviews but i need critical review since it is urgent and we don't have a lot of resources to apply.