### PR TITLE
RP-311 - Add tuning options to multi-tenant DataSource to drop idle c…

### DIFF
--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElements.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElements.java
@@ -38,4 +38,10 @@ public interface DataSourceElements {
 
     Integer getMaxIdle();
 
+    Boolean isRemoveAbandoned();
+
+    Integer getRemoveAbandonedTimeout();
+
+    Boolean isLogAbandoned();
+
 }

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsProperties.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsProperties.java
@@ -22,6 +22,10 @@ public class DataSourceElementsProperties implements DataSourceElements {
     private Integer maxActive;
     private Integer minIdle;
     private Integer maxIdle;
+    private Boolean removeAbandoned;
+    private Integer removeAbandonedTimeout;
+    private Boolean logAbandoned;
+
     private Map<String, DataSourceElementsTenant> tenants = new HashMap<>();
 
     @Override
@@ -139,6 +143,33 @@ public class DataSourceElementsProperties implements DataSourceElements {
 
     public void setMaxIdle(Integer maxIdle) {
         this.maxIdle = maxIdle;
+    }
+
+    @Override
+    public Boolean isRemoveAbandoned() {
+        return removeAbandoned;
+    }
+
+    public void setRemoveAbandoned(Boolean removeAbandoned) {
+        this.removeAbandoned = removeAbandoned;
+    }
+
+    @Override
+    public Integer getRemoveAbandonedTimeout() {
+        return removeAbandonedTimeout;
+    }
+
+    public void setRemoveAbandonedTimeout(Integer removeAbandonedTimeout) {
+        this.removeAbandonedTimeout = removeAbandonedTimeout;
+    }
+
+    @Override
+    public Boolean isLogAbandoned() {
+        return logAbandoned;
+    }
+
+    public void setLogAbandoned(Boolean logAbandoned) {
+        this.logAbandoned = logAbandoned;
     }
 
     public Map<String, DataSourceElementsTenant> getTenants() {

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsResolver.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsResolver.java
@@ -157,4 +157,25 @@ public class DataSourceElementsResolver implements DataSourceElements {
                 .orElse(dataSourceElementsProperties.getMaxIdle());
     }
 
+    @Override
+    public Boolean isRemoveAbandoned() {
+        return getResolvedDataSourceElementsTenant()
+                .map(DataSourceElementsTenant::isRemoveAbandoned)
+                .orElse(dataSourceElementsProperties.isRemoveAbandoned());
+    }
+
+    @Override
+    public Integer getRemoveAbandonedTimeout() {
+        return getResolvedDataSourceElementsTenant()
+                .map(DataSourceElementsTenant::getRemoveAbandonedTimeout)
+                .orElse(dataSourceElementsProperties.getRemoveAbandonedTimeout());
+    }
+
+    @Override
+    public Boolean isLogAbandoned() {
+        return getResolvedDataSourceElementsTenant()
+                .map(DataSourceElementsTenant::isLogAbandoned)
+                .orElse(dataSourceElementsProperties.isLogAbandoned());
+
+    }
 }

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsTenant.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsTenant.java
@@ -19,6 +19,9 @@ public class DataSourceElementsTenant implements DataSourceElements {
     private Integer maxActive;
     private Integer minIdle;
     private Integer maxIdle;
+    private Boolean removeAbandoned;
+    private Integer removeAbandonedTimeout;
+    private Boolean logAbandoned;
 
     @Override
     public String getUrl() {
@@ -135,5 +138,32 @@ public class DataSourceElementsTenant implements DataSourceElements {
 
     public void setMaxIdle(Integer maxIdle) {
         this.maxIdle = maxIdle;
+    }
+
+    @Override
+    public Boolean isRemoveAbandoned() {
+        return removeAbandoned;
+    }
+
+    public void setRemoveAbandoned(Boolean removeAbandoned) {
+        this.removeAbandoned = removeAbandoned;
+    }
+
+    @Override
+    public Integer getRemoveAbandonedTimeout() {
+        return removeAbandonedTimeout;
+    }
+
+    public void setRemoveAbandonedTimeout(Integer removeAbandonedTimeout) {
+        this.removeAbandonedTimeout = removeAbandonedTimeout;
+    }
+
+    @Override
+    public Boolean isLogAbandoned() {
+        return logAbandoned;
+    }
+
+    public void setLogAbandoned(Boolean logAbandoned) {
+        this.logAbandoned = logAbandoned;
     }
 }

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSource.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSource.java
@@ -77,6 +77,12 @@ public class TenantDynamicRoutingDataSource extends AbstractDynamicRoutingDataSo
                 .ifPresent(poolProperties::setMinIdle);
         Optional.ofNullable(dataSourceElements.getMaxIdle())
                 .ifPresent(poolProperties::setMaxIdle);
+        Optional.ofNullable(dataSourceElements.isRemoveAbandoned())
+                .ifPresent(poolProperties::setRemoveAbandoned);
+        Optional.ofNullable(dataSourceElements.getRemoveAbandonedTimeout())
+                .ifPresent(poolProperties::setRemoveAbandonedTimeout);
+        Optional.ofNullable(dataSourceElements.isLogAbandoned())
+                .ifPresent(poolProperties::setLogAbandoned);
 
         return new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
     }

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsIT.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsIT.java
@@ -8,13 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
@@ -23,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ActiveProfiles(profiles = {"tenant_ca","tenant_nv"})
+@ActiveProfiles(profiles = {"tenant_ca", "tenant_nv"})
 @EnableConfigurationProperties
 public class DataSourceElementsIT {
 
@@ -46,7 +42,7 @@ public class DataSourceElementsIT {
     }
 
     @Test
-    public void testDataSourceElementsResolverToTenantCa(){
+    public void testDataSourceElementsResolverToTenantCa() {
         TenantContextHolder.setTenantId("tenant_ca");
         assertThat(dataSourceElementsResolver.getUrl())
                 .isEqualTo("jdbc:mysql://localhost:3306/tenant_ca?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&connectTimeout=10000&socketTimeout=40000");
@@ -72,11 +68,18 @@ public class DataSourceElementsIT {
                 .isEqualTo(4);
         assertThat(dataSourceElementsResolver.getMaxIdle())
                 .isEqualTo(10);
+        assertThat(dataSourceElementsResolver.isRemoveAbandoned())
+                .isEqualTo(false);
+        assertThat(dataSourceElementsResolver.getRemoveAbandonedTimeout())
+                .isEqualTo(60);
+        assertThat(dataSourceElementsResolver.isLogAbandoned())
+                .isEqualTo(false);
+
         TenantContextHolder.clear();
     }
 
     @Test
-    public void testDataSourceElementsResolverToTenantNv(){
+    public void testDataSourceElementsResolverToTenantNv() {
         TenantContextHolder.setTenantId("tenant_nv");
         assertThat(dataSourceElementsResolver.getUrl())
                 .isEqualTo("jdbc:mysql://localhost:3306/tenant_nv?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&connectTimeout=10000&socketTimeout=40000");
@@ -114,14 +117,14 @@ public class DataSourceElementsIT {
 
         @Bean
         @ConfigurationProperties(prefix = "spring.datasource")
-        public DataSourceElementsProperties dataSourceElementsProperties(){
+        public DataSourceElementsProperties dataSourceElementsProperties() {
             return new DataSourceElementsProperties();
         }
 
 
         @Bean
-        public DataSourceElementsResolver dataSourceElementsResolver(){
-            return new DataSourceElementsResolver(tenantIdResolver(),dataSourceElementsProperties());
+        public DataSourceElementsResolver dataSourceElementsResolver() {
+            return new DataSourceElementsResolver(tenantIdResolver(), dataSourceElementsProperties());
         }
     }
 

--- a/multi-tenant/src/test/resources/application.yml
+++ b/multi-tenant/src/test/resources/application.yml
@@ -31,3 +31,6 @@ spring:
     maxActive: 10
     minIdle: ${spring.datasource.initialSize}
     maxIdle: ${spring.datasource.maxActive}
+    removeAbandoned: false
+    removeAbandonedTimeout: 60
+    logAbandoned: false


### PR DESCRIPTION
…onnections

https://jira.fairwaytech.com/browse/RP-311

>As configuration are changed (new tenants added) existing data sources will no longer be referenced. There is no way to close the database connections, but by using https://tomcat.apache.org/tomcat-8.5-doc/jdbc-pool.html "removeAbandoned" related settings we should be able to clean them up as they drop out of use. 