### PR TITLE
RP-387: fix security hole with scripts starting new threads

### DIFF
--- a/script/src/main/java/org/opentestsystem/rdw/script/security/SandboxSecurityManager.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/security/SandboxSecurityManager.java
@@ -14,7 +14,7 @@ public class SandboxSecurityManager extends SecurityManager {
     private static final DisableSecurityManagerPermission DISABLE_PERMISSION = new DisableSecurityManagerPermission();
 
     private final SandboxPermissions sandboxPermissions;
-    private final ThreadLocal<Boolean> enabledFlag;
+    private final InheritableThreadLocal<Boolean> enabledFlag;
 
     /**
      * Creates a SandboxSecurityManager with the given SandboxPermissions to use when enabled. For it to take effect,
@@ -27,7 +27,7 @@ public class SandboxSecurityManager extends SecurityManager {
     public SandboxSecurityManager(final SandboxPermissions sandboxPermissions) {
         this.sandboxPermissions = sandboxPermissions;
 
-        this.enabledFlag = new ThreadLocal<Boolean>() {
+        this.enabledFlag = new InheritableThreadLocal<Boolean>() {
 
             @Override
             protected Boolean initialValue() {

--- a/script/src/main/resources/scripts/DSLScriptBase.groovy
+++ b/script/src/main/resources/scripts/DSLScriptBase.groovy
@@ -26,6 +26,10 @@ import java.nio.charset.StandardCharsets
  * Base class for Groovy pipeline scripts. Provides a DSL that will be available to the scripts.
  */
 abstract class DSLScriptBase extends PipelineScript {
+    static {
+        Thread.metaClass.start {throw new SecurityException("Illegal to start new thread from script")}
+    }
+
     // Collection of errors found by validating scripts.
     private DataElementErrorCollector errorCollector = new DataElementErrorCollector()
 

--- a/script/src/main/resources/scripts/DSLScriptBase.groovy
+++ b/script/src/main/resources/scripts/DSLScriptBase.groovy
@@ -27,6 +27,8 @@ import java.nio.charset.StandardCharsets
  */
 abstract class DSLScriptBase extends PipelineScript {
     static {
+        // Disable starting new threads from the script. They complicate error handling
+        // and might be used to bypass security restrictions.
         Thread.metaClass.start {throw new SecurityException("Illegal to start new thread from script")}
     }
 

--- a/script/src/test/java/org/opentestsystem/rdw/script/SandboxTest.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/SandboxTest.java
@@ -28,7 +28,6 @@ import org.opentestsystem.rdw.script.security.SandboxSecurityManager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.when;
 
 
@@ -50,6 +49,7 @@ public class SandboxTest {
     @BeforeClass
     public static void changeSecurityPolicy() {
         sandboxSecurityManager = new SandboxSecurityManager(new DefaultSandboxPermissions());
+        sandboxSecurityManager.disable();
         System.setSecurityManager(sandboxSecurityManager);
     }
 
@@ -148,6 +148,24 @@ public class SandboxTest {
         runInSandbox(scriptCode, Collections.emptyMap());
     }
 
+    @Test
+    public void itShouldErrorOnStartThread() throws Exception {
+        exception.expect(ScriptRuntimeException.class);
+        exception.expectCause(instanceOf(SecurityException.class));
+
+        final String scriptCode =
+                        "new Thread() {\n" +
+                        "  public void run() {\n" +
+                                "FileWriter fw = new FileWriter('/tmp/hello')\n" +
+                                "fw.write('urfed')\n" +
+                                "fw.flush()\n" +
+                                "fw.close()" +
+                        "  }\n" +
+                        "}.start()";
+
+        runInSandbox(scriptCode, Collections.emptyMap());
+    }
+
 
     @Test
     public void itShouldErrorOnDisableSandboxFromProperty() throws Exception {
@@ -173,7 +191,7 @@ public class SandboxTest {
 
         Future<Object> future = pool.submit(callable);
         try {
-            return future.get();
+           return future.get();
         } catch (ExecutionException e) {
             throw (Exception)(e.getCause());
         }


### PR DESCRIPTION
I tried a few different fixes for this. One was to default the security manager to be enabled for new threads and then just disable it for the main thread. That worked to an extent, but some non-script threads still ended up with an enabled security manager, and in some of the JUnits, this caused a deadlock in a finalizer. I couldn't figure out exactly why. 

In any case, this solution, when it finally occurred to me is laughably simple, and yet it's effective. It might be hackable, but I couldn't figure out a way.