### PR TITLE
add tenants info to status

### DIFF
--- a/status/build.gradle
+++ b/status/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    compile project(':rdw-common-multi-tenant')
+
     compile 'com.google.guava:guava'
 
     // For StatusMvcEndpoint

--- a/status/src/main/java/org/opentestsystem/rdw/common/status/StatusConfiguration.java
+++ b/status/src/main/java/org/opentestsystem/rdw/common/status/StatusConfiguration.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.common.status;
 
+import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.springframework.boot.actuate.endpoint.ConfigurationPropertiesReportEndpoint;
 import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
 import org.springframework.context.annotation.Bean;
@@ -50,5 +51,10 @@ public class StatusConfiguration {
             final ConfigurationPropertiesReportEndpoint configurationEndpoint,
             final EnvironmentEndpoint environmentEndpoint) {
         return new ConfigurationStatusIndicator(configurationEndpoint, environmentEndpoint);
+    }
+
+    @Bean
+    public TenantsStatusIndicator tenantsStatusIndicator(final TenantProperties tenantProperties) {
+        return new TenantsStatusIndicator(tenantProperties);
     }
 }

--- a/status/src/main/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicator.java
+++ b/status/src/main/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicator.java
@@ -1,0 +1,30 @@
+package org.opentestsystem.rdw.common.status;
+
+import org.opentestsystem.rdw.multitenant.TenantProperties;
+
+/**
+ * {@link StatusIndicator} for tenant properties.
+ */
+public class TenantsStatusIndicator extends AbstractStatusIndicator {
+
+    private final TenantProperties tenantProperties;
+
+    public TenantsStatusIndicator(final TenantProperties tenantProperties) {
+        this.tenantProperties = tenantProperties;
+    }
+
+    @Override
+    public String name() {
+        return "tenants";
+    }
+
+    @Override
+    protected boolean doLevelCheck(final int level) {
+        return DiagnosticLevel.Configuration.isLessThanOrEqualTo(level);
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
+        builder.detail("tenant-properties", tenantProperties.getTenants());
+    }
+}

--- a/status/src/test/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicatorTest.java
+++ b/status/src/test/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicatorTest.java
@@ -1,0 +1,48 @@
+package org.opentestsystem.rdw.common.status;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TenantsStatusIndicatorTest {
+
+    private TenantsStatusIndicator statusIndicator;
+
+    @Before
+    public void createStatusIndicator() {
+        final TenantProperties tenantProperties = new TenantProperties();
+        tenantProperties.setTenants(ImmutableMap.of(
+            "CA", Tenant.builder().id("CA").key("CA").name("California").build(),
+            "NV", Tenant.builder().id("NV").key("NV").name("Nevada").build()
+        ));
+
+        statusIndicator = new TenantsStatusIndicator(tenantProperties);
+    }
+
+    @Test
+    public void itShouldReturnItsName() {
+        assertThat(statusIndicator.name()).isEqualTo("tenants");
+    }
+
+    @Test
+    public void itShouldBeConfigurationLevel() {
+        assertThat(statusIndicator.doLevelCheck(1)).isFalse();
+        assertThat(statusIndicator.doLevelCheck(2)).isTrue();
+    }
+
+    @Test
+    public void itShouldUseEndpointsToGetDetails() {
+        final Status status = statusIndicator.status(2);
+
+        assertThat(status.getStatusRating()).isEqualTo(4);
+        final Map<String, Object> tenantProperties = (Map<String, Object>) status.getDetails().get("tenant-properties");
+        assertThat(tenantProperties).hasSize(2);
+        assertThat(tenantProperties.keySet()).contains("CA", "NV");
+    }
+}

--- a/status/src/test/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicatorTest.java
+++ b/status/src/test/java/org/opentestsystem/rdw/common/status/TenantsStatusIndicatorTest.java
@@ -37,7 +37,7 @@ public class TenantsStatusIndicatorTest {
     }
 
     @Test
-    public void itShouldUseEndpointsToGetDetails() {
+    public void itShouldReturnTenantPropertiesInDetails() {
         final Status status = statusIndicator.status(2);
 
         assertThat(status.getStatusRating()).isEqualTo(4);


### PR DESCRIPTION
This adds a block to the status payload:
```
  "tenants": {
    "statusText": "Ideal",
    "statusRating": 4,
    "tenant-properties": {
      "CA": {
        "id": "CA",
        "key": "CA",
        "name": "California",
        "sandbox": false,
        "created": "2019-06-30T16:45:53.159Z"
      },
      "TS": {
        "id": "TS",
        "key": "TS",
        "name": "Test Tenant",
        "sandbox": false,
        "created": "2019-06-30T16:45:53.157Z"
      }
    }
  },
```