### PR TITLE
remove any hint of query timeout

### DIFF
--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElements.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElements.java
@@ -16,8 +16,6 @@ public interface DataSourceElements {
 
     DataSourceUrlParts getUrlParts();
 
-    String getJdbcInterceptors();
-
     String getUsername();
 
     String getPassword();
@@ -28,7 +26,7 @@ public interface DataSourceElements {
 
     String getValidationQuery();
 
-    Integer getValidationQueryTimeout();
+    Integer getValidationInterval();
 
     String getDriverClassName();
 

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsProperties.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsProperties.java
@@ -25,13 +25,12 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
 
     private String url;
     private DataSourceUrlParts urlParts;
-    private String jdbcInterceptors;
     private String username;
     private String password;
     private String schemaSearchPath;
     private Boolean testWhileIdle;
     private String validationQuery;
-    private Integer validationQueryTimeout;
+    private Integer validationInterval;
     private String driverClassName;
     private Integer initialSize;
     private Integer maxActive;
@@ -62,15 +61,6 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
 
     public void setUrlParts(DataSourceUrlParts urlParts) {
         this.urlParts = urlParts;
-    }
-
-    @Override
-    public String getJdbcInterceptors() {
-        return jdbcInterceptors;
-    }
-
-    public void setJdbcInterceptors(String jdbcInterceptors) {
-        this.jdbcInterceptors = jdbcInterceptors;
     }
 
     @Override
@@ -119,12 +109,12 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
     }
 
     @Override
-    public Integer getValidationQueryTimeout() {
-        return validationQueryTimeout;
+    public Integer getValidationInterval() {
+        return validationInterval;
     }
 
-    public void setValidationQueryTimeout(Integer validationQueryTimeout) {
-        this.validationQueryTimeout = validationQueryTimeout;
+    public void setValidationInterval(Integer validationInterval) {
+        this.validationInterval = validationInterval;
     }
 
     @Override
@@ -222,13 +212,12 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
                 "created=" + created +
                 ", url='" + url + '\'' +
                 ", urlParts=" + urlParts +
-                ", jdbcInterceptors='" + jdbcInterceptors + '\'' +
                 ", username='" + username + '\'' +
                 ", password='" + "REDACTED" + '\'' +
                 ", schemaSearchPath='" + schemaSearchPath + '\'' +
                 ", testWhileIdle=" + testWhileIdle +
                 ", validationQuery='" + validationQuery + '\'' +
-                ", validationQueryTimeout=" + validationQueryTimeout +
+                ", validationInterval=" + validationInterval +
                 ", driverClassName='" + driverClassName + '\'' +
                 ", initialSize=" + initialSize +
                 ", maxActive=" + maxActive +
@@ -248,13 +237,12 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
         DataSourceElementsProperties that = (DataSourceElementsProperties) o;
         return Objects.equal(url, that.url) &&
                 Objects.equal(urlParts, that.urlParts) &&
-                Objects.equal(jdbcInterceptors, that.jdbcInterceptors) &&
                 Objects.equal(username, that.username) &&
                 Objects.equal(password, that.password) &&
                 Objects.equal(schemaSearchPath, that.schemaSearchPath) &&
                 Objects.equal(testWhileIdle, that.testWhileIdle) &&
                 Objects.equal(validationQuery, that.validationQuery) &&
-                Objects.equal(validationQueryTimeout, that.validationQueryTimeout) &&
+                Objects.equal(validationInterval, that.validationInterval) &&
                 Objects.equal(driverClassName, that.driverClassName) &&
                 Objects.equal(initialSize, that.initialSize) &&
                 Objects.equal(maxActive, that.maxActive) &&
@@ -268,6 +256,6 @@ public class DataSourceElementsProperties implements DataSourceElements, TenantC
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(url, urlParts, jdbcInterceptors, username, password, schemaSearchPath, testWhileIdle, validationQuery, validationQueryTimeout, driverClassName, initialSize, maxActive, minIdle, maxIdle, removeAbandoned, removeAbandonedTimeout, logAbandoned, tenants);
+        return Objects.hashCode(url, urlParts, username, password, schemaSearchPath, testWhileIdle, validationQuery, validationInterval, driverClassName, initialSize, maxActive, minIdle, maxIdle, removeAbandoned, removeAbandonedTimeout, logAbandoned, tenants);
     }
 }

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsResolver.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsResolver.java
@@ -1,8 +1,6 @@
 package org.opentestsystem.rdw.multitenant.datasource;
 
 import org.opentestsystem.rdw.multitenant.TenantKeyResolver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -11,8 +9,6 @@ import java.util.Optional;
  * is under main configuration in "tenants" namespace
  */
 public class DataSourceElementsResolver implements DataSourceElements {
-
-    private static final Logger logger = LoggerFactory.getLogger(DataSourceElementsResolver.class);
 
     private final TenantKeyResolver tenantKeyResolver;
     private final DataSourceElementsProperties dataSourceElementsProperties;
@@ -71,13 +67,6 @@ public class DataSourceElementsResolver implements DataSourceElements {
     }
 
     @Override
-    public String getJdbcInterceptors() {
-        return getResolvedDataSourceElementsTenant()
-                .map(DataSourceElementsTenant::getJdbcInterceptors)
-                .orElse(dataSourceElementsProperties.getJdbcInterceptors());
-    }
-
-    @Override
     public String getUsername() {
         return getResolvedDataSourceElementsTenant()
                 .map(DataSourceElementsTenant::getUsername)
@@ -113,10 +102,10 @@ public class DataSourceElementsResolver implements DataSourceElements {
     }
 
     @Override
-    public Integer getValidationQueryTimeout() {
+    public Integer getValidationInterval() {
         return getResolvedDataSourceElementsTenant()
-                .map(DataSourceElementsTenant::getValidationQueryTimeout)
-                .orElse(dataSourceElementsProperties.getValidationQueryTimeout());
+                .map(DataSourceElementsTenant::getValidationInterval)
+                .orElse(dataSourceElementsProperties.getValidationInterval());
     }
 
     @Override

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsTenant.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsTenant.java
@@ -15,13 +15,12 @@ public class DataSourceElementsTenant implements DataSourceElements {
 
     private String url;
     private DataSourceUrlParts urlParts;
-    private String jdbcInterceptors;
     private String username;
     private String password;
     private String schemaSearchPath;
     private Boolean testWhileIdle;
     private String validationQuery;
-    private Integer validationQueryTimeout;
+    private Integer validationInterval;
     private String driverClassName;
     private Integer initialSize;
     private Integer maxActive;
@@ -48,16 +47,6 @@ public class DataSourceElementsTenant implements DataSourceElements {
     @JsonAlias({"url-parts", "url_parts"})
     public void setUrlParts(DataSourceUrlParts urlParts) {
         this.urlParts = urlParts;
-    }
-
-    @Override
-    public String getJdbcInterceptors() {
-        return jdbcInterceptors;
-    }
-
-    @JsonAlias({"jdbc-interceptors", "jdbc_interceptors"})
-    public void setJdbcInterceptors(String jdbcInterceptors) {
-        this.jdbcInterceptors = jdbcInterceptors;
     }
 
     @Override
@@ -109,13 +98,13 @@ public class DataSourceElementsTenant implements DataSourceElements {
     }
 
     @Override
-    public Integer getValidationQueryTimeout() {
-        return validationQueryTimeout;
+    public Integer getValidationInterval() {
+        return validationInterval;
     }
 
     @JsonAlias({"validation-query-timeout", "validation_query_timeout"})
-    public void setValidationQueryTimeout(Integer validationQueryTimeout) {
-        this.validationQueryTimeout = validationQueryTimeout;
+    public void setValidationInterval(Integer validationInterval) {
+        this.validationInterval = validationInterval;
     }
 
     @Override
@@ -203,13 +192,12 @@ public class DataSourceElementsTenant implements DataSourceElements {
         return "DataSourceElementsTenant{" +
                 "url='" + url + '\'' +
                 ", urlParts=" + urlParts +
-                ", jdbcInterceptors='" + jdbcInterceptors + '\'' +
                 ", username='" + username + '\'' +
                 ", password='" + "REDACTED" + '\'' +
                 ", schemaSearchPath='" + schemaSearchPath + '\'' +
                 ", testWhileIdle=" + testWhileIdle +
                 ", validationQuery='" + validationQuery + '\'' +
-                ", validationQueryTimeout=" + validationQueryTimeout +
+                ", validationInterval=" + validationInterval +
                 ", driverClassName='" + driverClassName + '\'' +
                 ", initialSize=" + initialSize +
                 ", maxActive=" + maxActive +
@@ -228,13 +216,12 @@ public class DataSourceElementsTenant implements DataSourceElements {
         DataSourceElementsTenant that = (DataSourceElementsTenant) o;
         return Objects.equal(url, that.url) &&
                 Objects.equal(urlParts, that.urlParts) &&
-                Objects.equal(jdbcInterceptors, that.jdbcInterceptors) &&
                 Objects.equal(username, that.username) &&
                 Objects.equal(password, that.password) &&
                 Objects.equal(schemaSearchPath, that.schemaSearchPath) &&
                 Objects.equal(testWhileIdle, that.testWhileIdle) &&
                 Objects.equal(validationQuery, that.validationQuery) &&
-                Objects.equal(validationQueryTimeout, that.validationQueryTimeout) &&
+                Objects.equal(validationInterval, that.validationInterval) &&
                 Objects.equal(driverClassName, that.driverClassName) &&
                 Objects.equal(initialSize, that.initialSize) &&
                 Objects.equal(maxActive, that.maxActive) &&
@@ -247,6 +234,6 @@ public class DataSourceElementsTenant implements DataSourceElements {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(url, urlParts, jdbcInterceptors, username, password, schemaSearchPath, testWhileIdle, validationQuery, validationQueryTimeout, driverClassName, initialSize, maxActive, minIdle, maxIdle, removeAbandoned, removeAbandonedTimeout, logAbandoned);
+        return Objects.hashCode(url, urlParts, username, password, schemaSearchPath, testWhileIdle, validationQuery, validationInterval, driverClassName, initialSize, maxActive, minIdle, maxIdle, removeAbandoned, removeAbandonedTimeout, logAbandoned);
     }
 }

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSource.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSource.java
@@ -49,8 +49,6 @@ public class TenantDynamicRoutingDataSource extends AbstractDynamicRoutingDataSo
 
         Optional.ofNullable(dataSourceElements.getUrl())
                 .ifPresent(poolProperties::setUrl);
-        Optional.ofNullable(dataSourceElements.getJdbcInterceptors())
-                .ifPresent(poolProperties::setJdbcInterceptors);
         Optional.ofNullable(dataSourceElements.getUsername())
                 .ifPresent(poolProperties::setUsername);
         Optional.ofNullable(dataSourceElements.getPassword())
@@ -59,8 +57,8 @@ public class TenantDynamicRoutingDataSource extends AbstractDynamicRoutingDataSo
                 .ifPresent(poolProperties::setTestWhileIdle);
         Optional.ofNullable(dataSourceElements.getValidationQuery())
                 .ifPresent(poolProperties::setValidationQuery);
-        Optional.ofNullable(dataSourceElements.getValidationQueryTimeout())
-                .ifPresent(poolProperties::setValidationQueryTimeout);
+        Optional.ofNullable(dataSourceElements.getValidationInterval())
+                .ifPresent(poolProperties::setValidationInterval);
         Optional.ofNullable(dataSourceElements.getDriverClassName())
                 .ifPresent(poolProperties::setDriverClassName);
         Optional.ofNullable(dataSourceElements.getInitialSize())

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsIT.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/DataSourceElementsIT.java
@@ -48,8 +48,6 @@ public class DataSourceElementsIT {
         TenantContextHolder.setTenantId("CA");
         assertThat(dataSourceElementsResolver.getUrl())
                 .isEqualTo("jdbc:mysql://localhost:3306/tenant_ca?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&connectTimeout=10000&socketTimeout=40000");
-        assertThat(dataSourceElementsResolver.getJdbcInterceptors())
-                .isEqualTo("QueryTimeoutInterceptor(queryTimeout=30)");
         assertThat(dataSourceElementsResolver.getUsername())
                 .isEqualTo("tenant_ca_user");
         assertThat(dataSourceElementsResolver.getPassword())
@@ -60,8 +58,8 @@ public class DataSourceElementsIT {
                 .isEqualTo(true);
         assertThat(dataSourceElementsResolver.getValidationQuery())
                 .isEqualTo("SELECT 1");
-        assertThat(dataSourceElementsResolver.getValidationQueryTimeout())
-                .isEqualTo(50);
+        assertThat(dataSourceElementsResolver.getValidationInterval())
+                .isEqualTo(35000);
         assertThat(dataSourceElementsResolver.getDriverClassName())
                 .isEqualTo("com.mysql.jdbc.Driver");
         assertThat(dataSourceElementsResolver.getInitialSize())
@@ -87,8 +85,6 @@ public class DataSourceElementsIT {
         TenantContextHolder.setTenantId("NV");
         assertThat(dataSourceElementsResolver.getUrl())
                 .isEqualTo("jdbc:mysql://localhost:3306/tenant_nv?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&connectTimeout=10000&socketTimeout=40000");
-        assertThat(dataSourceElementsResolver.getJdbcInterceptors())
-                .isEqualTo("QueryTimeoutInterceptor(queryTimeout=30)");
         assertThat(dataSourceElementsResolver.getUsername())
                 .isEqualTo("tenant_nv_user");
         assertThat(dataSourceElementsResolver.getPassword())
@@ -97,8 +93,8 @@ public class DataSourceElementsIT {
                 .isEqualTo(true);
         assertThat(dataSourceElementsResolver.getValidationQuery())
                 .isEqualTo("SELECT 1");
-        assertThat(dataSourceElementsResolver.getValidationQueryTimeout())
-                .isEqualTo(10000);
+        assertThat(dataSourceElementsResolver.getValidationInterval())
+                .isEqualTo(35000);
         assertThat(dataSourceElementsResolver.getDriverClassName())
                 .isEqualTo("com.mysql.jdbc.Driver");
         assertThat(dataSourceElementsResolver.getInitialSize())

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSourceTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/datasource/TenantDynamicRoutingDataSourceTest.java
@@ -37,12 +37,11 @@ public class TenantDynamicRoutingDataSourceTest {
         dataSourceElements = new DataSourceElementsTenant();
         dataSourceElements.setUrl(dataSourceUrl);
         dataSourceElements.setUrlParts(new DataSourceUrlParts());
-        dataSourceElements.setJdbcInterceptors("QueryTimeoutInterceptor(queryTimeout=30)");
         dataSourceElements.setUsername("mock-user");
         dataSourceElements.setPassword("mock-password");
         dataSourceElements.setTestWhileIdle(false);
         dataSourceElements.setValidationQuery("SELECT 1");
-        dataSourceElements.setValidationQueryTimeout(10000);
+        dataSourceElements.setValidationInterval(35000);
         dataSourceElements.setDriverClassName("com.mysql.jdbc.Driver");
         dataSourceElements.setInitialSize(0);
         dataSourceElements.setMaxActive(1);
@@ -82,8 +81,6 @@ public class TenantDynamicRoutingDataSourceTest {
         assertThat(dataSource).isNotNull();
         assertThat(dataSource.getPoolProperties()
                 .getUrl()).isEqualTo(dataSourceUrl);
-        assertThat(dataSource.getPoolProperties()
-                .getJdbcInterceptors()).isEqualTo(dataSourceElements.getJdbcInterceptors());
         assertThat(dataSource.getPoolProperties()
                 .getUsername()).isEqualTo(dataSourceElements.getUsername());
         assertThat(dataSource.getPoolProperties()

--- a/multi-tenant/src/test/resources/application-tenant_ca.yml
+++ b/multi-tenant/src/test/resources/application-tenant_ca.yml
@@ -16,7 +16,6 @@ spring:
         username: "tenant_ca_user"
         password: "tenant_ca_password"
         schema-search-path: "ca_schema"
-        validationQueryTimeout: 50
 archive:
   tenants:
     CA:

--- a/multi-tenant/src/test/resources/application.yml
+++ b/multi-tenant/src/test/resources/application.yml
@@ -19,12 +19,11 @@ spring:
                    &socketTimeout=${spring.datasource.socket-timeout:40000}\
                    "
     url: "${spring.datasource.url-parts.protocol}//${spring.datasource.url-parts.hosts}/${spring.datasource.url-parts.database}?${spring.datasource.url-parts.properties}"
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:30})"
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
-    validationQueryTimeout: 10000
+    validationInterval: 35000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     initialSize: 4


### PR DESCRIPTION
setQueryTimeout is not well-behaved, especially when destroying statements/connections. So let's get rid of it. Also, let's override the validationInterval which defaults to 3s.

Both those things are unnecessary because our application is fairly well behaved.