### PR TITLE
RP-631 exam-processor needs to be made tenant aware of "validation.requiredDataElements"

### DIFF
--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationProperties.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationProperties.java
@@ -1,0 +1,10 @@
+package org.opentestsystem.rdw.multitenant.validation;
+
+import java.util.List;
+
+/**
+ * Interface for POJOs for reading exam processor validation properties
+ */
+public interface ExamProcessorValidationProperties {
+    List<String> getRequiredDataElements();
+}

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesResolver.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesResolver.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.multitenant.validation;
+
+import org.opentestsystem.rdw.multitenant.TenantKeyResolver;
+import org.opentestsystem.rdw.multitenant.datasource.DataSourceElements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tenant specific {@link ExamProcessorValidationProperties} assumes tenant configuration
+ * is under main configuration in "tenants" namespace
+ */
+public class ExamProcessorValidationPropertiesResolver implements ExamProcessorValidationProperties {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExamProcessorValidationPropertiesResolver.class);
+
+    private final TenantKeyResolver tenantKeyResolver;
+    private final ExamProcessorValidationPropertiesRoot propertiesRoot;
+
+    public ExamProcessorValidationPropertiesResolver(TenantKeyResolver tenantKeyResolver,
+                                                     ExamProcessorValidationPropertiesRoot propertiesRoot) {
+        this.tenantKeyResolver = tenantKeyResolver;
+        this.propertiesRoot = propertiesRoot;
+        logger.debug("ExamProcessorValidationPropertiesRoot: {}", propertiesRoot);
+    }
+
+    @Override
+    public List<String> getRequiredDataElements() {
+        return getExamProcessorValidationPropertiesTenant()
+                .map(ExamProcessorValidationPropertiesTenant::getRequiredDataElements)
+                .orElse(propertiesRoot.getRequiredDataElements());
+    }
+
+    private Optional<ExamProcessorValidationPropertiesTenant> getExamProcessorValidationPropertiesTenant() {
+        return tenantKeyResolver.getTenantKey()
+                .flatMap(k -> Optional.ofNullable(propertiesRoot.getTenants().get(k)));
+    }
+
+}

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesRoot.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesRoot.java
@@ -1,0 +1,34 @@
+package org.opentestsystem.rdw.multitenant.validation;
+
+import com.google.common.base.Objects;
+
+import java.util.HashMap;
+
+/**
+ * Root POJO for tenant aware reading/writing exam processor validation properties
+ */
+public class ExamProcessorValidationPropertiesRoot extends ExamProcessorValidationPropertiesTenant {
+
+    private HashMap<String, ExamProcessorValidationPropertiesTenant> tenants = new HashMap<>();
+
+    public HashMap<String, ExamProcessorValidationPropertiesTenant> getTenants() {
+        return tenants;
+    }
+
+    public void setTenants(HashMap<String, ExamProcessorValidationPropertiesTenant> tenants) {
+        this.tenants = tenants;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExamProcessorValidationPropertiesRoot)) return false;
+        ExamProcessorValidationPropertiesRoot that = (ExamProcessorValidationPropertiesRoot) o;
+        return Objects.equal(tenants, that.tenants);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tenants);
+    }
+}

--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesTenant.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesTenant.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.rdw.multitenant.validation;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * POJO for reading/writing exam processor validation properties
+ * <p>
+ * The JsonAlias annotations make it so it will read properties using rules
+ * that mimic Spring's relaxed binding.
+ * </p>
+ */
+public class ExamProcessorValidationPropertiesTenant implements ExamProcessorValidationProperties {
+
+    private ArrayList<String> requiredDataElements = new ArrayList<>();
+
+    @Override
+    public List<String> getRequiredDataElements() {
+        return requiredDataElements;
+    }
+
+    @JsonAlias({"required-data-elements", "required_data_elements"})
+    public void setRequiredDataElements(List<String> requiredDataElements) {
+        this.requiredDataElements = Lists.newArrayList(requiredDataElements);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExamProcessorValidationPropertiesTenant)) return false;
+        ExamProcessorValidationPropertiesTenant that = (ExamProcessorValidationPropertiesTenant) o;
+        return Objects.equal(requiredDataElements, that.requiredDataElements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(requiredDataElements);
+    }
+}

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesResolverTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/validation/ExamProcessorValidationPropertiesResolverTest.java
@@ -1,0 +1,83 @@
+package org.opentestsystem.rdw.multitenant.validation;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.multitenant.TenantContextHolder;
+import org.opentestsystem.rdw.multitenant.TenantIdResolver;
+import org.opentestsystem.rdw.multitenant.TenantKeyResolver;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles(profiles = {"tenant_ca", "tenant_nv"})
+@EnableConfigurationProperties
+public class ExamProcessorValidationPropertiesResolverTest {
+
+    @Autowired
+    ExamProcessorValidationPropertiesResolver examProcessorValidationProperties;
+
+    @Test
+    public void caShouldResolveOverride() {
+        TenantContextHolder.setTenantId("CA");
+        List<String> result = examProcessorValidationProperties.getRequiredDataElements();
+        assertThat(result).contains("FirstName");
+        assertThat(result).contains("LastOrSurname");
+        assertThat(result).contains("Birthdate");
+        assertThat(result.size()).isEqualTo(3);
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    public void nvShouldResolveDefault() {
+        TenantContextHolder.setTenantId("NV");
+        List<String> result = examProcessorValidationProperties.getRequiredDataElements();
+        assertThat(result.size()).isEqualTo(8);
+        TenantContextHolder.clear();
+    }
+
+    @Configuration
+    static class Config {
+        @Bean
+        @ConfigurationProperties(prefix = "tenantProperties")
+        TenantProperties tenantProperties() {
+            return new TenantProperties();
+        }
+
+        @Bean
+        public TenantIdResolver tenantIdResolver() {
+            return () -> Optional.ofNullable(TenantContextHolder.getTenantId());
+        }
+
+        @Bean
+        TenantKeyResolver tenantKeyResolver(TenantProperties tenantProperties,
+                                            TenantIdResolver tenantIdResolver) {
+            return new TenantKeyResolver(tenantProperties, tenantIdResolver);
+        }
+
+        @Bean
+        @ConfigurationProperties("validation")
+        ExamProcessorValidationPropertiesRoot examProcessorValidationPropertiesRoot() {
+            return new ExamProcessorValidationPropertiesRoot();
+        }
+
+        @Bean
+        ExamProcessorValidationPropertiesResolver examProcessorValidationProperties(TenantKeyResolver tenantKeyResolver,
+                                                                                    ExamProcessorValidationPropertiesRoot aggregateReportingPropertiesRoot) {
+            return new ExamProcessorValidationPropertiesResolver(tenantKeyResolver, aggregateReportingPropertiesRoot);
+        }
+    }
+}

--- a/multi-tenant/src/test/resources/application-tenant_ca.yml
+++ b/multi-tenant/src/test/resources/application-tenant_ca.yml
@@ -21,3 +21,11 @@ archive:
     CA:
       uri-root: "s3://ca-archive"
       path-prefix: "/ca"
+
+validation:
+  tenants:
+    CA:
+      requiredDataElements:
+        - FirstName
+        - LastOrSurname
+        - Birthdate

--- a/multi-tenant/src/test/resources/application.yml
+++ b/multi-tenant/src/test/resources/application.yml
@@ -41,3 +41,14 @@ archive:
   s3-secret-key: testsecret
   s3-region-static: us-west-2
   s3-sse: testsse
+
+validation:
+  requiredDataElements:
+    - FirstName
+    - LastOrSurname
+    - Birthdate
+    - Sex
+    - EconomicDisadvantageStatus
+    - IDEAIndicator
+    - Completeness
+    - AdministrationCondition


### PR DESCRIPTION
- tenant aware resolver
- switch to list of strings from list of enum direct binding (see related ingest PR)

Note this is the first PR others are forthcoming in down-stream projects