### PR TITLE
pull up tenant configurable task elements to top level

### DIFF
--- a/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesTenant.java
+++ b/multi-tenant/src/main/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesTenant.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class SendReconciliationReportPropertiesTenant {
     private List<ArchivePropertiesTenant> archives = new ArrayList<ArchivePropertiesTenant>();
     private boolean log;
+    private String query;
 
     public List<ArchivePropertiesTenant> getArchives() {
         return archives;
@@ -26,17 +27,26 @@ public class SendReconciliationReportPropertiesTenant {
         this.log = log;
     }
 
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof SendReconciliationReportPropertiesTenant)) return false;
         SendReconciliationReportPropertiesTenant tenant = (SendReconciliationReportPropertiesTenant) o;
         return log == tenant.log &&
-                Objects.equal(archives, tenant.archives);
+                Objects.equal(archives, tenant.archives) &&
+                Objects.equal(query, tenant.query);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(archives, log);
+        return Objects.hashCode(archives, log, query);
     }
 }

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/ArtClientPropertiesResolverTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/ArtClientPropertiesResolverTest.java
@@ -80,7 +80,7 @@ public class ArtClientPropertiesResolverTest {
         }
 
         @Bean
-        @ConfigurationProperties("task.update-organizations.art-client")
+        @ConfigurationProperties("task-update-organizations-art-client")
         ArtClientPropertiesRoot artClientPropertiesRoot() {
             return new ArtClientPropertiesRoot();
         }

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/ImportServiceClientPropertiesResolverTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/ImportServiceClientPropertiesResolverTest.java
@@ -74,7 +74,7 @@ public class ImportServiceClientPropertiesResolverTest {
         }
 
         @Bean
-        @ConfigurationProperties("task.update-organizations.import-service-client")
+        @ConfigurationProperties("task-update-organizations-import-service-client")
         ImportServiceClientPropertiesRoot importServiceClientPropertiesRoot() {
             return new ImportServiceClientPropertiesRoot();
         }

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesRootTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesRootTest.java
@@ -33,6 +33,7 @@ public class SendReconciliationReportPropertiesRootTest {
     public void tenantCa() {
         SendReconciliationReportPropertiesTenant tenant = sendReconciliationReportPropertiesRoot.getTenants().get("CA");
         assertThat(tenant.isLog()).isFalse();
+        assertThat(tenant.getQuery()).contains("status=PROCESSED&after=-PT24H");
         assertThat(tenant.getArchives().size()).isEqualTo(2);
         Optional<ArchivePropertiesTenant> file = tenant.getArchives().stream().filter(a -> a.getUriRoot().contains("file")).findFirst();
         assertThat(file).isPresent();
@@ -50,7 +51,8 @@ public class SendReconciliationReportPropertiesRootTest {
     @Test
     public void tenantNv() {
         SendReconciliationReportPropertiesTenant tenant = sendReconciliationReportPropertiesRoot.getTenants().get("NV");
-        assertThat(tenant.isLog()).isFalse();
+        assertThat(tenant.isLog()).isTrue();
+        assertThat(tenant.getQuery()).contains("status=PROCESSED&after=-PT12H");
         assertThat(tenant.getArchives().size()).isEqualTo(1);
         Optional<ArchivePropertiesTenant> file = tenant.getArchives().stream().filter(a -> a.getUriRoot().contains("file")).findFirst();
         assertThat(file).isPresent();

--- a/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesRootTest.java
+++ b/multi-tenant/src/test/java/org/opentestsystem/rdw/multitenant/task/SendReconciliationReportPropertiesRootTest.java
@@ -76,7 +76,7 @@ public class SendReconciliationReportPropertiesRootTest {
         }
 
         @Bean
-        @ConfigurationProperties("task.send-reconciliation-report")
+        @ConfigurationProperties("task-send-reconciliation-report")
         SendReconciliationReportPropertiesRoot sendReconciliationReportPropertiesRoot() {
             return new SendReconciliationReportPropertiesRoot();
         }

--- a/multi-tenant/src/test/resources/application-tenant_ca.yml
+++ b/multi-tenant/src/test/resources/application-tenant_ca.yml
@@ -48,6 +48,7 @@ taskSendReconciliationReport:
   tenants:
     CA:
       log: false
+      query: status=PROCESSED&after=-PT24H
       archives:
         - uri-root: file:///tmp/
         - uri-root: s3:///bucket

--- a/multi-tenant/src/test/resources/application-tenant_ca.yml
+++ b/multi-tenant/src/test/resources/application-tenant_ca.yml
@@ -30,28 +30,28 @@ validation:
         - LastOrSurname
         - Birthdate
 
-task:
-  update-organizations:
-    art-client:
-      tenants:
-        CA:
-          oauth2:
-            username: ca.user@example.com
-            password: caPwd!
-    import-service-client:
-      tenants:
-        CA:
-          oauth2:
-            username: ca.user@example.com
-            password: caPwd!
-  send-reconciliation-report:
-    tenants:
-      CA:
-        log: false
-        archives:
-          - uri-root: file:///tmp/
-          - uri-root: s3:///bucket
-            s3-access-key: AccessKey
-            s3-secret-key: SecretKey
-            s3-region-static: us-west-2
-            s3-sse: AES256
+taskUpdateOrganizationsArtClient:
+  tenants:
+    CA:
+      oauth2:
+        username: ca.user@example.com
+        password: caPwd!
+
+taskUpdateOrganizationsImportServiceClient:
+  tenants:
+    CA:
+      oauth2:
+        username: ca.user@example.com
+        password: caPwd!
+
+taskSendReconciliationReport:
+  tenants:
+    CA:
+      log: false
+      archives:
+        - uri-root: file:///tmp/
+        - uri-root: s3:///bucket
+          s3-access-key: AccessKey
+          s3-secret-key: SecretKey
+          s3-region-static: us-west-2
+          s3-sse: AES256

--- a/multi-tenant/src/test/resources/application-tenant_nv.yml
+++ b/multi-tenant/src/test/resources/application-tenant_nv.yml
@@ -24,10 +24,9 @@ archive:
       uri-root: "file://tmp"
       path-prefix: "/nv"
 
-task:
-  send-reconciliation-report:
-    tenants:
-      NV:
-        log: false
-        archives:
-          - uri-root: file:///tmp/
+taskSendReconciliationReport:
+  tenants:
+    NV:
+      log: false
+      archives:
+        - uri-root: file:///tmp/

--- a/multi-tenant/src/test/resources/application-tenant_nv.yml
+++ b/multi-tenant/src/test/resources/application-tenant_nv.yml
@@ -27,6 +27,7 @@ archive:
 taskSendReconciliationReport:
   tenants:
     NV:
-      log: false
+      log: true
+      query: status=PROCESSED&after=-PT12H
       archives:
         - uri-root: file:///tmp/

--- a/multi-tenant/src/test/resources/application.yml
+++ b/multi-tenant/src/test/resources/application.yml
@@ -53,24 +53,23 @@ validation:
     - Completeness
     - AdministrationCondition
 
-task:
-  update-organizations:
-    art-client:
-      groups-of-districts-url: https://art-deployment.sbtds.org/rest/groupofdistrict?stateAbbreviation={state}&pageSize=1000
-      districts-url: https://art-deployment.sbtds.org/rest/district?stateAbbreviation={state}&pageSize=5000
-      groups-of-schools-url: https://art-deployment.sbtds.org/rest/groupofinstitution?stateAbbreviation={state}&pageSize=1000
-      schools-url:
-      status-url: https://art-deployment.sbtds.org/rest/status
-      oauth2:
-        access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
-        client-id: sbacdw
-        client-secret:
-        username: prime.user@example.com
-        password:
-    import-service-client:
-      organizations-imports-url: http://localhost:8080/organizations/imports
-      status-url: http://localhost:8081/status
-      oauth2:
-        access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
-        client-id: sbacdw
-        client-secret:
+taskUpdateOrganizationsArtClient:
+  groups-of-districts-url: https://art-deployment.sbtds.org/rest/groupofdistrict?stateAbbreviation={state}&pageSize=1000
+  districts-url: https://art-deployment.sbtds.org/rest/district?stateAbbreviation={state}&pageSize=5000
+  groups-of-schools-url: https://art-deployment.sbtds.org/rest/groupofinstitution?stateAbbreviation={state}&pageSize=1000
+  schools-url:
+  status-url: https://art-deployment.sbtds.org/rest/status
+  oauth2:
+    access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
+    client-id: sbacdw
+    client-secret:
+    username: prime.user@example.com
+    password:
+
+taskUpdateOrganizationsImportServiceClient:
+  organizations-imports-url: http://localhost:8080/organizations/imports
+  status-url: http://localhost:8081/status
+  oauth2:
+    access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
+    client-id: sbacdw
+    client-secret:


### PR DESCRIPTION
from a code perspective not much of a change
       `@ConfigurationProperties("task.update-organizations.import-service-client")`
becomes
        `@ConfigurationProperties("task-update-organizations-import-service-client")`

some rework of the embedded application yml will be required