### PR TITLE
RP-809: restore instantiation of script object for each pipeline run

### DIFF
--- a/script/src/main/java/org/opentestsystem/rdw/script/Pipeline.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/Pipeline.java
@@ -157,7 +157,9 @@ public class Pipeline {
     }
 
     /**
-     * Get an instance of the script to be run against the given input
+     * Get an instance of the script to be run against the given input.
+     * This constructs a copy of the script with the original bound properties and source
+     * to guarantee we have a fresh instance with no memory of previous processing.
      *
      * @param prototype prototype instance of the Pipeline script
      * @param input input for the script to work on. The type is script dependent.

--- a/script/src/main/java/org/opentestsystem/rdw/script/Pipeline.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/Pipeline.java
@@ -1,6 +1,6 @@
 package org.opentestsystem.rdw.script;
 
-import org.opentestsystem.rdw.script.security.AbstractToggleableSecurityManager;
+import groovy.lang.MissingPropertyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.opentestsystem.rdw.script.security.AbstractToggleableSecurityManager;
 
 import static com.google.common.collect.ImmutableList.copyOf;
 
@@ -29,6 +30,7 @@ public class Pipeline {
     private final List<PipelineScript> scripts;
     private final AbstractToggleableSecurityManager sandboxSecurityManager;
 
+    // TODO: restore the implementation that passes a list of PipelineDefinitions instead of PipelineScripts.
     public Pipeline(
             @NotNull final PipelineDefinition source,
             @NotNull final List<PipelineScript> scripts,
@@ -61,8 +63,10 @@ public class Pipeline {
 
         Object lastValidTransformation = input;
 
-        for (final PipelineScript script : scripts) {
+        for (final PipelineScript prototype : scripts) {
+            PipelineScript script = null;
             try {
+                script = getInstance(prototype, lastValidTransformation);
                 script.bindInput(lastValidTransformation);
 
                 final Object results = runScript(script);
@@ -152,4 +156,27 @@ public class Pipeline {
         return null;
     }
 
+    /**
+     * Get an instance of the script to be run against the given input
+     *
+     * @param prototype prototype instance of the Pipeline script
+     * @param input input for the script to work on. The type is script dependent.
+     * @return an instance of a PipelineScript
+     * @throws Exception if there is an problem constructing the script
+     */
+    private PipelineScript getInstance(final PipelineScript prototype, final Object input) throws Exception {
+        // TODO: this method should be updated to work with PipelineDefinition, not PipelineScript
+        final PipelineScript script = prototype.getClass().getConstructor().newInstance()
+                .bindProperties(prototype.getBoundProperties())
+                .source(prototype.getSource())
+                .bindInput(input);
+
+        try {
+            script.setProperty("propertyResolver", prototype.getProperty("propertyResolver"));
+        } catch (MissingPropertyException e) {
+            logger.info("No property resolver set");
+        }
+
+        return script;
+    }
 }

--- a/script/src/main/java/org/opentestsystem/rdw/script/PipelineDefinitions.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/PipelineDefinitions.java
@@ -1,5 +1,8 @@
 package org.opentestsystem.rdw.script;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Instant;
 import java.util.Properties;
 
@@ -7,6 +10,7 @@ import java.util.Properties;
  * Holds utility methods for published pipelines
  */
 public final class PipelineDefinitions {
+    private static final Logger logger = LoggerFactory.getLogger(PipelineDefinitions.class);
 
     // Note the property keys had to be all lower case due to the way Amazon S3 coerces all property names to lower case
     private static final String PipelineCodeProperty = "pipeline_code";
@@ -41,9 +45,18 @@ public final class PipelineDefinitions {
         return PipelineDefinition.builder()
                 .pipelineCode(properties.getProperty(PipelineCodeProperty))
                 .version(properties.getProperty(VersionProperty))
-                .published(Instant.parse(properties.getProperty(PublishedOnProperty)))
+                .published(parseInstant(properties.getProperty(PublishedOnProperty)))
                 .publishedBy(properties.getProperty(PublishedByProperty))
                 .build();
+    }
+
+    private static Instant parseInstant(final String timeString) {
+        try {
+            return Instant.parse(timeString);
+        } catch (Exception e) {
+            logger.warn("Cannot parse instant string: " + timeString, e);
+            return null;
+        }
     }
 
     private PipelineDefinitions() {}

--- a/script/src/main/java/org/opentestsystem/rdw/script/PipelineScript.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/PipelineScript.java
@@ -1,12 +1,9 @@
 package org.opentestsystem.rdw.script;
 
-import com.google.common.collect.ImmutableMap;
 import groovy.lang.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.print.attribute.HashDocAttributeSet;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,7 +14,7 @@ public abstract class PipelineScript extends Script {
     protected static final Logger logger = LoggerFactory.getLogger(PipelineScript.class);
 
     private PipelineScriptDefinition source;
-    private Map<String,Object> boundProperties = Collections.EMPTY_MAP;
+    private Map<String,Object> boundProperties = new HashMap<>();
 
     public PipelineScriptDefinition getSource() {
         return source;
@@ -37,24 +34,13 @@ public abstract class PipelineScript extends Script {
      */
     public PipelineScript bindProperties(Map<String, Object> properties) {
         if (properties != null && !properties.isEmpty()) {
-            addBoundProperties(properties);
+            boundProperties.putAll(properties);
+
             for (Map.Entry<String,Object> entry : properties.entrySet()) {
                 this.setProperty(entry.getKey(), entry.getValue());
             }
         }
         return this;
-    }
-
-    private void addBoundProperties(final Map<String, Object> properties) {
-        Map<String,Object> allProperties = properties;
-
-        if (!boundProperties.isEmpty()) {
-            // Rare case. Add newly bound properties to previously bound ones.
-            allProperties = new HashMap<>(boundProperties);
-            allProperties.putAll(properties);
-        }
-
-        boundProperties = ImmutableMap.copyOf(allProperties);
     }
 
     /**

--- a/script/src/main/java/org/opentestsystem/rdw/script/PipelineScript.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/PipelineScript.java
@@ -1,9 +1,13 @@
 package org.opentestsystem.rdw.script;
 
+import com.google.common.collect.ImmutableMap;
 import groovy.lang.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.print.attribute.HashDocAttributeSet;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -13,6 +17,7 @@ public abstract class PipelineScript extends Script {
     protected static final Logger logger = LoggerFactory.getLogger(PipelineScript.class);
 
     private PipelineScriptDefinition source;
+    private Map<String,Object> boundProperties = Collections.EMPTY_MAP;
 
     public PipelineScriptDefinition getSource() {
         return source;
@@ -31,13 +36,33 @@ public abstract class PipelineScript extends Script {
      * @return this object (used for chaining calls)
      */
     public PipelineScript bindProperties(Map<String, Object> properties) {
-        if (properties != null) {
+        if (properties != null && !properties.isEmpty()) {
+            addBoundProperties(properties);
             for (Map.Entry<String,Object> entry : properties.entrySet()) {
                 this.setProperty(entry.getKey(), entry.getValue());
             }
         }
-
         return this;
+    }
+
+    private void addBoundProperties(final Map<String, Object> properties) {
+        Map<String,Object> allProperties = properties;
+
+        if (!boundProperties.isEmpty()) {
+            // Rare case. Add newly bound properties to previously bound ones.
+            allProperties = new HashMap<>(boundProperties);
+            allProperties.putAll(properties);
+        }
+
+        boundProperties = ImmutableMap.copyOf(allProperties);
+    }
+
+    /**
+     * Returns a map of the properties that have been bound to this script class, but not including the bound input.
+     * @return an Immutable map of bound properties.
+     */
+    public Map<String,Object> getBoundProperties() {
+        return boundProperties;
     }
 
     /**

--- a/script/src/main/java/org/opentestsystem/rdw/script/security/DefaultSandboxPermissions.java
+++ b/script/src/main/java/org/opentestsystem/rdw/script/security/DefaultSandboxPermissions.java
@@ -34,6 +34,7 @@ public class DefaultSandboxPermissions implements SandboxPermissions {
         whitelist.add(new PropertyPermission("file.separator", "read"));
         whitelist.add(new PropertyPermission("path.separator", "read"));
         whitelist.add(new PropertyPermission("java.class.version", "read"));
+        whitelist.add(new PropertyPermission("java.version", "read"));
         whitelist.add(new PropertyPermission("java.home", "read"));
         whitelist.add(new PropertyPermission("file.encoding", "read"));
         whitelist.add(new PropertyPermission("com.sun.security.*", "read"));

--- a/script/src/test/java/org/opentestsystem/rdw/script/PipelineScriptTest.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/PipelineScriptTest.java
@@ -1,0 +1,44 @@
+package org.opentestsystem.rdw.script;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PipelineScriptTest {
+    PipelineScript pipelineScript;
+
+    @Before
+    public void setUp() throws Exception {
+        pipelineScript = new PipelineScript() {
+            @Override
+            public Object run() {
+                return "OK";
+            }
+        };
+    }
+
+    @Test
+    public void itShouldTrackBoundProperties() {
+        final Map<String,Object> properties = ImmutableMap.of("propA", "stringValue", "propB", 11, "propC", true);
+        pipelineScript.bindProperties(properties);
+        assertThat(pipelineScript.getBoundProperties()).isEqualTo(properties);
+    }
+
+    @Test
+    public void isShouldTrackMultipleBinds() {
+        final Map<String,Object> properties1 = ImmutableMap.of("propA", "stringValue", "propB", 11, "propC", true);
+        final Map<String,Object> properties2 = ImmutableMap.of("propB", 12, "propD", "anotherStringValue");
+        final Map<String,Object> allProperties = new HashMap<>(properties1);
+        allProperties.putAll(properties2);
+
+        pipelineScript.bindProperties(properties1);
+        pipelineScript.bindProperties(properties2);
+
+        assertThat(pipelineScript.getBoundProperties()).isEqualTo(allProperties);
+    }
+}

--- a/script/src/test/java/org/opentestsystem/rdw/script/PipelineTest.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/PipelineTest.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.rdw.script;
 
 import org.junit.Test;
+
+import java.util.Collections;
 import org.opentestsystem.rdw.script.security.AbstractToggleableSecurityManager;
 import org.opentestsystem.rdw.script.security.DefaultSandboxPermissions;
 import org.opentestsystem.rdw.script.security.DefaultSandboxSecurityManager;
-
-import java.util.Collections;
-import java.util.function.Supplier;
+import org.opentestsystem.rdw.script.util.SamplePipelineScript;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,26 +17,16 @@ import static org.opentestsystem.rdw.script.PipelineScriptType.User;
 public class PipelineTest {
 
 
-    public static final PipelineScript pipelineScript(final PipelineScriptType type) {
-        return pipelineScript(type, null);
+    private static PipelineScript pipelineScript(final PipelineScriptType type) {
+        return pipelineScript(type, null, null);
     }
-    public static final <T> PipelineScript pipelineScript(final PipelineScriptType type, final T output) {
-        return pipelineScript(type, () -> output);
+    private static PipelineScript pipelineScript(
+            final PipelineScriptType type, final Object output, final RuntimeException exception) {
+        return new SamplePipelineScript(type, output, exception);
     }
-    public static final <T> PipelineScript pipelineScript(final PipelineScriptType type, final Supplier<T> output) {
-        return new PipelineScript() {
-            @Override
-            public PipelineScriptDefinition getSource() {
-                return PipelineScriptDefinition.builder()
-                        .type(type)
-                        .build();
-            }
-
-            @Override
-            public Object run() {
-                return output.get();
-            }
-        };
+    private static PipelineScript pipelineScript(
+            final PipelineScriptType type, final Object output) {
+        return new SamplePipelineScript(type, output, null);
     }
 
     // TODO would like to mock this but it causes a stack overflow
@@ -133,8 +123,8 @@ public class PipelineTest {
         final Pipeline pipeline = new Pipeline(
                 pipelineWithUserScript,
                 newArrayList(
-                        pipelineScript(User, "nope"),
                         pipelineScript(Pre, "not me"),
+                        pipelineScript(User, "nope"),
                         pipelineScript(Post, expectedOutput)
                 ),
                 securityManager
@@ -167,9 +157,7 @@ public class PipelineTest {
         final Pipeline pipeline = new Pipeline(
                 pipelineWithUserScript,
                 newArrayList(
-                        pipelineScript(User, () -> {
-                            throw new RuntimeException("boom");
-                        })
+                        pipelineScript(User, null, new RuntimeException("boom"))
                 ),
                 securityManager
         );
@@ -177,4 +165,16 @@ public class PipelineTest {
         pipeline.run("input");
     }
 
+    @Test(expected = RuntimeException.class)
+    public void itShouldTrackErrors() {
+        final Pipeline pipeline = new Pipeline(
+                pipelineWithUserScript,
+                newArrayList(
+                        pipelineScript(User, null, new RuntimeException("boom"))
+                ),
+                securityManager
+        );
+
+        pipeline.run("input");
+    }
 }

--- a/script/src/test/java/org/opentestsystem/rdw/script/TextPipelineTest.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/TextPipelineTest.java
@@ -17,6 +17,8 @@ import org.opentestsystem.rdw.script.security.AbstractToggleableSecurityManager;
 import org.opentestsystem.rdw.script.security.DefaultSandboxPermissions;
 import org.opentestsystem.rdw.script.security.DefaultSandboxSecurityManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.script.util.Tests.resourceAsString;
@@ -74,7 +76,7 @@ public class TextPipelineTest {
         );
     }
 
-    @Test(expected = ImportException.class)
+    @Test
     public void itShouldFailOnValidationErrors() throws Exception {
         // Test ability to filter out elements with a boolean rule. All elements matching the XPath expression
         // and also matching this rule will be removed.
@@ -87,11 +89,10 @@ public class TextPipelineTest {
 
         Pipeline pipeline = pipelineFactory.getPipeline(PIPELINE_NAME, PIPELINE_VERSION);
 
-        try {
-            pipeline.run("good input");
-        } catch (ScriptRuntimeException sre) {
-            throw (Exception)sre.getCause();
-        }
+        assertThatThrownBy(() -> {
+            pipeline.run("bad input");
+            fail("Expected a script exception for bad input");
+        }).hasCauseInstanceOf(ImportException.class);
     }
 
     @Test
@@ -106,13 +107,12 @@ public class TextPipelineTest {
 
         Pipeline pipeline = pipelineFactory.getPipeline(PIPELINE_NAME, PIPELINE_VERSION);
 
-        try {
+        assertThatThrownBy(() -> {
             pipeline.run("bad input");
             fail("Expected a script exception for bad input");
-        } catch (ScriptRuntimeException sre) {
-        }
+        }).hasCauseInstanceOf(ImportException.class);
 
-        pipeline.run("good input");
+        assertThat(pipeline.run("good input").asString()).isEqualTo("good input");
     }
 
     private PipelineDefinition pipelineWithUserScript(final String userScript) throws IOException {

--- a/script/src/test/java/org/opentestsystem/rdw/script/TextPipelineTest.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/TextPipelineTest.java
@@ -1,0 +1,137 @@
+package org.opentestsystem.rdw.script;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.opentestsystem.rdw.common.model.ImportException;
+import org.opentestsystem.rdw.script.impl.EmptyPropertyResolver;
+import org.opentestsystem.rdw.script.impl.ResourceLoaderScriptSource;
+import org.opentestsystem.rdw.script.publishing.PublishedPipelineRepository;
+import org.opentestsystem.rdw.script.security.AbstractToggleableSecurityManager;
+import org.opentestsystem.rdw.script.security.DefaultSandboxPermissions;
+import org.opentestsystem.rdw.script.security.DefaultSandboxSecurityManager;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.script.util.Tests.resourceAsString;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TextPipelineTest {
+    private static final String PIPELINE_NAME = "My Test Pipeline";
+    private static final String PIPELINE_VERSION = "1.0";
+
+    private PipelineFactory pipelineFactory;
+    private ScriptPipelineConfiguration config = new ScriptPipelineConfiguration();
+
+    private static AbstractToggleableSecurityManager sandboxSecurityManager;
+
+    @Mock
+    private PublishedPipelineRepository repository;
+
+    private PipelineDefinition pipelineDefinition;
+
+    @BeforeClass
+    public static void setupSecurityManager() {
+        sandboxSecurityManager = new DefaultSandboxSecurityManager(new DefaultSandboxPermissions());
+    }
+
+    @Before
+    public void before() {
+
+        pipelineDefinition = PipelineDefinition.builder()
+                .pipelineCode(PIPELINE_NAME)
+                .version(PIPELINE_VERSION)
+                .scripts(Arrays.asList(
+                        PipelineScriptDefinition.builder()
+                                .type(PipelineScriptType.User)
+                                .version("1.0")
+                                .body("")
+                                .build(),
+                        PipelineScriptDefinition.builder()
+                                .type(PipelineScriptType.Base)
+                                .version("1.0")
+                                .body(resourceAsString("/scripts/DSLScriptBase.groovy"))
+                                .build()
+                ))
+                .build();
+
+        when(repository.findByCodeAndVersion(PIPELINE_NAME, PIPELINE_VERSION))
+                .thenReturn(pipelineDefinition);
+
+        PropertyResolver propertyResolver = new EmptyPropertyResolver();
+
+        pipelineFactory = config.pipelineFactory(
+                repository,
+                propertyResolver,
+                sandboxSecurityManager,
+                new ResourceLoaderScriptSource()
+        );
+    }
+
+    @Test(expected = ImportException.class)
+    public void itShouldFailOnValidationErrors() throws Exception {
+        // Test ability to filter out elements with a boolean rule. All elements matching the XPath expression
+        // and also matching this rule will be removed.
+        final String scriptCode =
+                        "addError('element', 'expected value', 'actual value is actual')\n" +
+                        "checkValid";
+
+        when(repository.findByCodeAndVersion(PIPELINE_NAME, PIPELINE_VERSION))
+                .thenReturn(pipelineWithUserScript(scriptCode));
+
+        Pipeline pipeline = pipelineFactory.getPipeline(PIPELINE_NAME, PIPELINE_VERSION);
+
+        try {
+            pipeline.run("good input");
+        } catch (ScriptRuntimeException sre) {
+            throw (Exception)sre.getCause();
+        }
+    }
+
+    @Test
+    public void itShouldNotCarryOverValidationErrors() throws Exception {
+        final String scriptCode =
+                        "if (input == 'bad input')\n" +
+                        "    addError('element', 'expected value', 'bad input')\n" +
+                        "checkValid";
+
+        when(repository.findByCodeAndVersion(PIPELINE_NAME, PIPELINE_VERSION))
+                .thenReturn(pipelineWithUserScript(scriptCode));
+
+        Pipeline pipeline = pipelineFactory.getPipeline(PIPELINE_NAME, PIPELINE_VERSION);
+
+        try {
+            pipeline.run("bad input");
+            fail("Expected a script exception for bad input");
+        } catch (ScriptRuntimeException sre) {
+        }
+
+        pipeline.run("good input");
+    }
+
+    private PipelineDefinition pipelineWithUserScript(final String userScript) throws IOException {
+        return PipelineDefinition.builder()
+                .pipelineCode(PIPELINE_NAME)
+                .version(PIPELINE_VERSION)
+                .scripts(Arrays.asList(
+                        PipelineScriptDefinition.builder()
+                                .type(PipelineScriptType.User)
+                                .version("1.0")
+                                .body(userScript)
+                                .build(),
+                        PipelineScriptDefinition.builder()
+                                .type(PipelineScriptType.Base)
+                                .version("1.0")
+                                .body(resourceAsString("/scripts/DSLScriptBase.groovy"))
+                                .build()
+                ))
+                .build();
+    }
+
+}

--- a/script/src/test/java/org/opentestsystem/rdw/script/util/SamplePipelineScript.java
+++ b/script/src/test/java/org/opentestsystem/rdw/script/util/SamplePipelineScript.java
@@ -1,0 +1,45 @@
+package org.opentestsystem.rdw.script.util;
+
+import com.google.common.collect.ImmutableMap;
+import groovy.lang.MissingPropertyException;
+
+import org.opentestsystem.rdw.script.PipelineScript;
+import org.opentestsystem.rdw.script.PipelineScriptDefinition;
+import org.opentestsystem.rdw.script.PipelineScriptType;
+
+public class SamplePipelineScript extends PipelineScript {
+    public SamplePipelineScript() {
+    }
+
+    public SamplePipelineScript(final PipelineScriptType type, final Object output, final RuntimeException exception) {
+        this.source(PipelineScriptDefinition.builder()
+                .type(type)
+                .build());
+
+        if (output != null) {
+            this.bindProperties(ImmutableMap.of("output", output));
+        }
+
+        if (exception != null) {
+            this.bindProperties(ImmutableMap.of("exception", exception));
+        }
+    }
+
+    @Override
+    public Object run() {
+        try {
+            final RuntimeException exception = (RuntimeException)this.getProperty("exception");
+            if (exception != null) {
+                throw exception;
+            }
+        } catch (MissingPropertyException | ClassCastException e) {
+            // Ignore
+        }
+
+        try {
+            return this.getProperty("output");
+        } catch (MissingPropertyException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This implementation is a bit unusual as it takes a script object and uses it as a prototype to create new script objects. Eventually, I'd  prefer to restore  the implementation that created  the Pipeline with the script classes and configuration, rather than script objects.  However, this will take more intensive refactoring and testing.